### PR TITLE
first take at making readme a bit more user friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/README.md
+++ b/README.md
@@ -1,26 +1,25 @@
-#Simple POS tagger
-A simple part of speech tagger. 
+# Simple POS tagger
+A simple part of speech tagger.
 
-#Installation
+### Installation
 The POS tagger can be installed using npm as follows:
 ```
 npm install simple-pos-tagger
 ```
 
-#Functionality
+### Functionality
 The tagger can be used to complement a tagger like Wordnet which covers nouns, verbs, adjectives and adverbs. The principle of the tagger is simple: per lexical category a list (in a file) can be supplied that is used to tag words. First line of the file defines the category. Words may occur in multiple lists.
 The tagger accepts an array of words as input and assigns to each word of the input a list of possible categories. See below for an example.
 
-#Usage
+### Usage
 ```
-var Tagger = require("SimplePOSTagger");
-var config_file = basedir + "data/English/lexicon.json";
+var Tagger = require("simple-pos-tagger");
+var config_file = __dirname + "./node_modules/simple-pos-tagger/data/English/lexicon_files.json";
 
-new Tagger(config_file, function(tagger) {
-  var sentence = ["I", "see", "the", "man", "with", "the", "telescope"];
-  var tagged_sentence = tagger.tag_sentence(sentence);
-  console.log(tagged_sentence);
-});
+var tagger = new Tagger(config_file, true);
+var sentence = ["I", "see", "the", "man", "with", "the", "telescope"];
+var tagged_sentence = tagger.tag_sentence(sentence);
+console.log(tagged_sentence);
 ```
 Output of the tagger is:
 ```
@@ -32,17 +31,102 @@ Output of the tagger is:
   [ 'the', [ 'determiner' ] ],
   [ 'telescope', undefined ] ]
 ```
-Note that the value of untagged words is <code>undefined</code>.
+Note that the value of untagged words is `undefined`.
+
+
 A variant of the tagger returns a chart instead of a tagged sentence (array) as shown above. This enables the tagger to recognise lexical items that cover more than one word.
-The chart is initialised with CYK items of the form <code>(A, i, j)</code>. 
+The chart is initialised with CYK items of the form `(A, i, j)`.
 ```
-var chart = tagger.tag_sentence(sentence);
+var util = require('util');
+var sentence = ["I", "see", "the", "man", "with", "the", "telescope"];
+var chart = tagger.tag_sentence_chart(sentence);
+console.log(util.inspect(chart, {depth: null}));
+```
+Output of the chart is:
+```
+{ N: 7,
+  outgoing_edges:
+   [ { 'CYK(personal_pronoun, 0, 1)':
+        [ { id: 'CYK(personal_pronoun, 0, 1)',
+            name: 'personal_pronoun',
+            children: [],
+            data:
+             { from: 0,
+               to: 1,
+               rule: { lhs: 'personal_pronoun', rhs: 'I' } } } ] },
+     {},
+     { 'CYK(determiner, 2, 3)':
+        [ { id: 'CYK(determiner, 2, 3)',
+            name: 'determiner',
+            children: [],
+            data:
+             { from: 2,
+               to: 3,
+               rule: { lhs: 'determiner', rhs: 'the' } } } ] },
+     {},
+     { 'CYK(preposition, 4, 5)':
+        [ { id: 'CYK(preposition, 4, 5)',
+            name: 'preposition',
+            children: [],
+            data:
+             { from: 4,
+               to: 5,
+               rule: { lhs: 'preposition', rhs: 'with' } } } ] },
+     { 'CYK(determiner, 5, 6)':
+        [ { id: 'CYK(determiner, 5, 6)',
+            name: 'determiner',
+            children: [],
+            data:
+             { from: 5,
+               to: 6,
+               rule: { lhs: 'determiner', rhs: 'the' } } } ] },
+     {},
+     {} ],
+  incoming_edges:
+   [ {},
+     { 'CYK(personal_pronoun, 0, 1)':
+        [ { id: 'CYK(personal_pronoun, 0, 1)',
+            name: 'personal_pronoun',
+            children: [],
+            data:
+             { from: 0,
+               to: 1,
+               rule: { lhs: 'personal_pronoun', rhs: 'I' } } } ] },
+     {},
+     { 'CYK(determiner, 2, 3)':
+        [ { id: 'CYK(determiner, 2, 3)',
+            name: 'determiner',
+            children: [],
+            data:
+             { from: 2,
+               to: 3,
+               rule: { lhs: 'determiner', rhs: 'the' } } } ] },
+     {},
+     { 'CYK(preposition, 4, 5)':
+        [ { id: 'CYK(preposition, 4, 5)',
+            name: 'preposition',
+            children: [],
+            data:
+             { from: 4,
+               to: 5,
+               rule: { lhs: 'preposition', rhs: 'with' } } } ] },
+     { 'CYK(determiner, 5, 6)':
+        [ { id: 'CYK(determiner, 5, 6)',
+            name: 'determiner',
+            children: [],
+            data:
+             { from: 5,
+               to: 6,
+               rule: { lhs: 'determiner', rhs: 'the' } } } ] },
+     {} ] }
 ```
 
-#Configuration
-The lexicon files are configured in <code>data/LANGUAGE/lexicon_files.json</code>. Example of a configuration file for English:
+### Configuration
+
+The lexicon files are configured in `data/LANGUAGE/lexicon_files.json`. Example of a configuration file for English:
 ```
-[ "adverb.txt",
+[
+  "adverb.txt",
   "indefinite_pronoun.txt",
   "possessive_pronoun.txt",
   "relative_pronoun.txt",

--- a/example/example-taggers.js
+++ b/example/example-taggers.js
@@ -1,47 +1,33 @@
-/*
-    A part-of-speech tagger for English function words
-    Copyright (C) 2015 Hugo W.L. ter Doest
+var Tagger = require("../");
+var util = require("util");
+var inspectOptions = {
+  depth: null,
+  colors: true
+};
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+var path_to_lexicon = __dirname + "/../data";
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+var config_files = {
+  dutch: path_to_lexicon + "/Dutch/lexicon_files.json",
+  english: path_to_lexicon + "/English/lexicon_files.json"
+};
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+var sentences = {
+  dutch: [
+    ["ik", "zie", "de", "man", "met", "de", "verrekijker"]
+  ],
+  english: [
+    ["I", "see", "the", "man", "with", "the", "telescope"],
+    ["in", "accordance", "with"]
+  ]
+};
 
-var Tagger = require("../lib/SimplePOSTagger");
+var dutchTagger = new Tagger(config_files.dutch, true);
+console.log(dutchTagger.tag_sentence(sentences.dutch[0]));
+console.log(util.inspect(dutchTagger.tag_sentence_chart(sentences.dutch[0]), inspectOptions));
 
-// Path to the lexicon files
-var path_to_lexicon = "/home/hugo/Workspace/simple_pos_tagger/data/";
-//var path_to_lexicon = "/Eclipse Workspace/function-word-tagger/data/";
-
-var config_files = [path_to_lexicon + "Dutch/lexicon_files.json", 
-                    path_to_lexicon + "English/lexicon_files.json"];
-
-var sentences = [["ik", "zie", "de", "man", "met", "de", "verrekijker"],
-                 ["I", "see", "the", "man", "with", "the", "telescope"],
-                 ["in", "accordance", "with"]];
-
-new Tagger(config_files[0], function(tagger) {
-  var tagged_sentence = tagger.tag_sentence(sentences[0]);
-  console.log(tagged_sentence);
-  var chart = tagger.tag_sentence_chart(sentences[0]);
-  console.log(chart);
-  new Tagger(config_files[1], function(tagger) {
-    var tagged_sentence = tagger.tag_sentence(sentences[1]);
-    console.log(tagged_sentence);
-    var chart = tagger.tag_sentence_chart(sentences[1]);
-    console.log(chart);
-    var tagged_sentence = tagger.tag_sentence(sentences[2]);
-    console.log(tagged_sentence);
-    var chart = tagger.tag_sentence_chart(sentences[2]);
-    console.log(JSON.stringify(chart, undefined, 2));
-  });
-});
+var englishTagger = new Tagger(config_files.english, true);
+console.log(englishTagger.tag_sentence(sentences.english[0]));
+console.log(util.inspect(englishTagger.tag_sentence_chart(sentences.english[0]), inspectOptions));
+console.log(englishTagger.tag_sentence(sentences.english[1]));
+console.log(util.inspect(englishTagger.tag_sentence_chart(sentences.english[1]), inspectOptions));

--- a/lib/SimplePOSTagger.js
+++ b/lib/SimplePOSTagger.js
@@ -114,7 +114,7 @@ SimplePOSTagger.prototype.readLexiconFromConfigFile = function(config_file) {
   this.maxLemmaLength = 0;
   this.config_file = path.basename(config_file);
   this.path_to_lexicon = path.dirname(config_file);
-  var files = fs.readFileSync(config_file, 'utf8');
+  var files = JSON.parse(fs.readFileSync(config_file, 'utf8'));
   files.forEach(function(filename) {
     var text = fs.readFileSync(that.path_to_lexicon + '/' + filename, 'utf8');
     that.read_words(text);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "url" : "http://github.com/Hugo-ter-Doest/simple-pos-tagger/issues"
   },
   "dependencies" : {
-    "fs" : "*",
     "log4js" : "*",
     "underscore": "*",
     "typeof": "*"


### PR DESCRIPTION
- updates README.md to reflect new non-callback constructor
  - adds chart output to readme
- changes the example/example-taggers.js to be accurate
- removes the `fs` package as that is a native node module and not needed
- adds a JSON.parse to the lib/SimplePOSTagger

The thing I don't know is if adding the `JSON.parse` to the `lib/SimplePOSTagger.js` correct or not. Please take a look and let me know.

One thing that still confuses me about this is the [constructor signature](https://github.com/Hugo-ter-Doest/simple-pos-tagger/blob/master/lib/SimplePOSTagger.js#L124). It looks like it takes a file name and then a boolean. If that isn't correct let me know. That is how I changed it in `README.md` and `examples/example-taggers.js`

You can take a look at the parsed markdown of the new readme [here](https://github.com/grobot/simple-pos-tagger#simple-pos-tagger).
